### PR TITLE
rendering performance enhancements

### DIFF
--- a/components/overview-chart.js
+++ b/components/overview-chart.js
@@ -1,17 +1,10 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
-import { Box, Divider, Flex, Label, useThemeUI } from 'theme-ui'
-import { alpha } from '@theme-ui/color'
+import { Box, Divider, Flex, useThemeUI } from 'theme-ui'
 import { useThemedColormap } from '@carbonplan/colormaps'
 
 import useStore, { variables } from '../store'
 import Timeseries from './timeseries'
-import {
-  openZarr,
-  getChunk,
-  getTimeSeriesData,
-  downloadCsv,
-  getColorForValue,
-} from '../utils'
+import { openZarr, getChunk, getTimeSeriesData, downloadCsv } from '../utils'
 import DownloadCSV from './download-csv'
 import Checkbox from './checkbox'
 
@@ -38,7 +31,6 @@ const OverviewChart = ({ sx }) => {
     (state) => state.setFilterToRegionsInView
   )
   const regionsInView = useStore((state) => state.regionsInView)
-  const overviewElapsedTime = useStore((state) => state.overviewElapsedTime)
   const currentVariable = useStore((state) => state.currentVariable)
   const variableFamily = useStore((state) => state.variableFamily)
   const setActiveLineData = useStore((state) => state.setActiveLineData)
@@ -80,14 +72,6 @@ const OverviewChart = ({ sx }) => {
       const transformed = timeSeriesData.reduce((acc, regionData, index) => {
         acc[index] = {
           id: index,
-          color: alpha(
-            getColorForValue(
-              regionData[overviewElapsedTime][1],
-              colormap,
-              currentVariable
-            ),
-            0.1
-          )(theme),
           activeColor: theme.rawColors?.primary,
           strokeWidth: 2,
           data: regionData,
@@ -122,7 +106,7 @@ const OverviewChart = ({ sx }) => {
       }
     })
     return selected
-  }, [regionsInView, filterToRegionsInView, overviewLineData, selectedRegion])
+  }, [regionsInView, filterToRegionsInView, overviewLineData])
 
   const handleClick = useCallback(
     (e) => {
@@ -198,7 +182,6 @@ const OverviewChart = ({ sx }) => {
               : currentVariable.unit,
         }}
         selectedLines={selectedLines}
-        elapsedYears={(overviewElapsedTime + 1) / 12}
         colormap={colormap}
         opacity={0.1}
         handleClick={hideFilter ? undefined : handleClick}

--- a/components/regions.js
+++ b/components/regions.js
@@ -358,13 +358,19 @@ const Regions = () => {
   }, [selectedRegion, selectedRegionCenter, map, setSelectedRegionCenter])
 
   useEffect(() => {
-    if (map && map.getSource('regions') && map.getLayer('regions-line')) {
+    if (map?.getSource('regions')) {
       map.setPaintProperty('regions-line', 'line-color', lineColor)
       map.setPaintProperty('regions-hover', 'line-color', lineHighlightColor)
       map.setPaintProperty(
         'regions-selected',
         'line-color',
         theme.rawColors.primary
+      )
+      map.setPaintProperty('regions-fill', 'fill-color', colorExpression)
+      map.setPaintProperty(
+        'selected-region-fill',
+        'fill-color',
+        colorExpression
       )
     }
   }, [map, theme])

--- a/components/regions.js
+++ b/components/regions.js
@@ -116,9 +116,10 @@ const Regions = () => {
           type: 'vector',
           promoteId: 'polygon_id',
           tiles: [
-            'https://carbonplan-oae-efficiency.s3.us-west-2.amazonaws.com/region-tiles/{z}/{x}/{y}.pbf',
+            'https://carbonplan-oae-efficiency.s3.us-west-2.amazonaws.com/region-tiles-compressed/{z}/{x}/{y}.pbf',
           ],
           maxzoom: 0,
+          minzoom: 0,
         })
       }
 

--- a/components/regions.js
+++ b/components/regions.js
@@ -28,7 +28,7 @@ const Regions = () => {
   const { map } = useMapbox()
   const { theme } = useThemeUI()
   const hoveredRegionRef = useRef(hoveredRegion)
-  const previouslySelectedRegionRef = useRef(null)
+  const previouslySelectedRegionRef = useRef(selectedRegion)
 
   //reused colors
   const transparent = 'rgba(0, 0, 0, 0)'

--- a/components/regions.js
+++ b/components/regions.js
@@ -116,7 +116,7 @@ const Regions = () => {
           type: 'vector',
           promoteId: 'polygon_id',
           tiles: [
-            'https://carbonplan-oae-efficiency.s3.us-west-2.amazonaws.com/region-tiles-compressed/{z}/{x}/{y}.pbf',
+            'https://carbonplan-oae-efficiency.s3.us-west-2.amazonaws.com/region-tiles/{z}/{x}/{y}.pbf',
           ],
           maxzoom: 0,
           minzoom: 0,

--- a/components/timeseries.js
+++ b/components/timeseries.js
@@ -109,14 +109,9 @@ const RenderLines = ({
   ))
 }
 
-const ActiveLine = ({ selectedLines }) => {
-  const hoveredRegion = useStore((s) => s.hoveredRegion)
-  const selectedRegion = useStore((s) => s.selectedRegion)
+const ActiveLine = () => {
+  const activeLineData = useStore((s) => s.activeLineData)
   const overviewElapsedTime = useStore((s) => s.overviewElapsedTime)
-
-  const activeRegion = hoveredRegion ?? selectedRegion
-  const activeLineData =
-    activeRegion !== null ? selectedLines[activeRegion] : null
 
   if (!activeLineData || !activeLineData.data) {
     return null
@@ -149,16 +144,11 @@ const ActiveLine = ({ selectedLines }) => {
   )
 }
 
-const OverviewBadge = ({ selectedLines }) => {
-  const hoveredRegion = useStore((s) => s.hoveredRegion)
-  const selectedRegion = useStore((s) => s.selectedRegion)
+const OverviewBadge = () => {
+  const activeLineData = useStore((s) => s.activeLineData)
   const overviewElapsedTime = useStore((s) => s.overviewElapsedTime)
   const currentVariable = useStore((s) => s.currentVariable)
   const colormap = useVariableColormap()
-
-  const activeRegion = hoveredRegion ?? selectedRegion
-  const activeLineData =
-    activeRegion !== null ? selectedLines[activeRegion] : null
 
   if (!activeLineData || !activeLineData.data) {
     return null
@@ -356,7 +346,7 @@ const Timeseries = ({
           />
           {Object.keys(selectedLines).length && (
             <>
-              {showActive && <ActiveLine selectedLines={selectedLines} />}
+              {showActive && <ActiveLine />}
               {xSelector && mousePosition && renderXSelector(mousePosition)}
               <TimeIndicator yLimits={yLimits} isOverview={isOverview} />
               {xSelector &&
@@ -371,7 +361,7 @@ const Timeseries = ({
           )}
         </Plot>
         {!xSelector && renderDataBadge()}
-        {showActive && <OverviewBadge selectedLines={selectedLines} />}
+        {showActive && <OverviewBadge />}
         {regionDataLoading && (
           <Box
             sx={{

--- a/components/timeseries.js
+++ b/components/timeseries.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { Box, Spinner } from 'theme-ui'
-import { alpha } from '@theme-ui/color'
 import {
   AxisLabel,
   Chart,
@@ -15,8 +14,9 @@ import {
 } from '@carbonplan/charts'
 import { Badge } from '@carbonplan/components'
 
-import useStore from '../store'
-import { formatValue } from '../utils'
+import useStore, { variables } from '../store'
+import { formatValue, useVariableColormap } from '../utils'
+import { getColorForValue } from '../utils/color'
 
 const renderPoint = (point) => {
   const { x, y, color } = point
@@ -35,7 +35,6 @@ const renderPoint = (point) => {
 const renderDataBadge = (point) => {
   if (!point || !point.text) return null
   const { x, y, color, text } = point
-  const fullColor = alpha(color, 1)
   return (
     <Point x={x} y={y} align={'center'} width={2}>
       <Badge
@@ -43,7 +42,7 @@ const renderDataBadge = (point) => {
           fontSize: 1,
           height: '20px',
           mt: 2,
-          bg: fullColor,
+          bg: color,
         }}
       >
         {text}
@@ -110,9 +109,14 @@ const RenderLines = ({
   ))
 }
 
-const ActiveLine = () => {
-  const activeLineData = useStore((s) => s.activeLineData)
+const ActiveLine = ({ selectedLines }) => {
+  const hoveredRegion = useStore((s) => s.hoveredRegion)
+  const selectedRegion = useStore((s) => s.selectedRegion)
   const overviewElapsedTime = useStore((s) => s.overviewElapsedTime)
+
+  const activeRegion = hoveredRegion ?? selectedRegion
+  const activeLineData =
+    activeRegion !== null ? selectedLines[activeRegion] : null
 
   if (!activeLineData || !activeLineData.data) {
     return null
@@ -145,18 +149,46 @@ const ActiveLine = () => {
   )
 }
 
-const OverviewBadge = () => {
-  const activeLineData = useStore((s) => s.activeLineData)
+const OverviewBadge = ({ selectedLines }) => {
+  const hoveredRegion = useStore((s) => s.hoveredRegion)
+  const selectedRegion = useStore((s) => s.selectedRegion)
   const overviewElapsedTime = useStore((s) => s.overviewElapsedTime)
+  const currentVariable = useStore((s) => s.currentVariable)
+  const colormap = useVariableColormap()
+
+  const activeRegion = hoveredRegion ?? selectedRegion
+  const activeLineData =
+    activeRegion !== null ? selectedLines[activeRegion] : null
+
   if (!activeLineData || !activeLineData.data) {
     return null
   }
-  const { color } = activeLineData
   const data = activeLineData.data[overviewElapsedTime]
+  const color = getColorForValue(data[1], colormap, currentVariable)
   const x = data[0]
   const y = data[1]
   const point = { x, y, color, text: formatValue(y) }
   return renderDataBadge(point)
+}
+
+const TimeIndicator = ({ yLimits, isOverview = false }) => {
+  const overviewElapsedTime = useStore((s) => s.overviewElapsedTime)
+  const detailElapsedTime = useStore((s) => s.detailElapsedTime)
+  const elapsedYears = isOverview
+    ? (overviewElapsedTime + 1) / 12
+    : (detailElapsedTime + 1) / 12
+
+  if (elapsedYears === undefined) return null
+  return (
+    <Line
+      data={[
+        [elapsedYears, yLimits[0]],
+        [elapsedYears, yLimits[1]],
+      ]}
+      color='primary'
+      style={{ strokeDasharray: '2 4' }}
+    />
+  )
 }
 
 const Timeseries = ({
@@ -167,7 +199,6 @@ const Timeseries = ({
   handleClick,
   handleHover,
   point,
-  elapsedYears,
   colormap,
   opacity,
   showActive = false,
@@ -181,6 +212,8 @@ const Timeseries = ({
   const [isHovering, setIsHovering] = useState(false)
   const [xSelectorValue, setXSelectorValue] = useState(null)
   const currentVariable = useStore((s) => s.currentVariable)
+  const variableFamily = useStore((s) => s.variableFamily)
+  const isOverview = variables[variableFamily].overview
 
   const xYearsMonth = (x) => {
     const years = Math.floor(x)
@@ -323,16 +356,9 @@ const Timeseries = ({
           />
           {Object.keys(selectedLines).length && (
             <>
-              {showActive && <ActiveLine />}
+              {showActive && <ActiveLine selectedLines={selectedLines} />}
               {xSelector && mousePosition && renderXSelector(mousePosition)}
-              <Line
-                data={[
-                  [elapsedYears, yLimits[0]],
-                  [elapsedYears, yLimits[1]],
-                ]}
-                color='primary'
-                style={{ strokeDasharray: '2 4' }}
-              />
+              <TimeIndicator yLimits={yLimits} isOverview={isOverview} />
               {xSelector &&
                 isHovering &&
                 renderPoint({
@@ -345,7 +371,7 @@ const Timeseries = ({
           )}
         </Plot>
         {!xSelector && renderDataBadge()}
-        {showActive && <OverviewBadge />}
+        {showActive && <OverviewBadge selectedLines={selectedLines} />}
         {regionDataLoading && (
           <Box
             sx={{

--- a/store/index.js
+++ b/store/index.js
@@ -303,15 +303,11 @@ const useStore = create((set) => ({
       ? set((state) => {
           const activeLineData =
             state.overviewLineData?.[selectedRegion] || null
-          const selectedRegionGeojson = state.regionGeojson.features.find(
-            (f) => f.properties.polygon_id === selectedRegion
-          )
           return {
             selectedRegion,
             currentVariable: variables.ALK.variables[0],
             variableFamily: 'ALK',
             activeLineData,
-            selectedRegionGeojson,
           }
         })
       : set((state) => {
@@ -343,9 +339,6 @@ const useStore = create((set) => ({
 
   overviewLineData: {},
   setOverviewLineData: (overviewLineData) => set({ overviewLineData }),
-
-  regionGeojson: null,
-  setRegionGeojson: (regionGeojson) => set({ regionGeojson }),
 
   selectedRegionGeojson: null,
   setSelectedRegionGeojson: (selectedRegionGeojson) =>


### PR DESCRIPTION
This PR does a couple things to improve rendering performance of the overview variables charts/map

* Isolates `overviewElapsedTime` from the overall chart to just a component that renders the time indicator, which prevents redrawing all lines as a user scrubs through time. 
* Refactors `Regions` to use `featureState` to handle updates to values instead of swapping out the source geojson with updated values. 
* Uses gzip compressed vector tiles to load region geometries (all data in a single 15kb tile, compared to 293kb geojson before!)

We'll want to do some decent testing here, especially related to the map in different states of rendering the regions (eg selected polygon viewing overview variables in various states). The `Regions` component has become pretty complex, so the change here is pretty high touch, unfortunately. 